### PR TITLE
Add oss-reproducible to the build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Also see:
 * [buildsec/frsca](https://github.com/buildsec/frsca) is an implementation of the CNCF's Secure Software Factory Reference Architecture. It is also intended to follow SLSA requirements closely and generate in-toto attesttations for SLSA provenance predicates.
 * [aquasecurity/chain-bench: an open-source tool for auditing your software supply chain stack for security compliance](https://github.com/aquasecurity/chain-bench) implementing checks for [CIS 1.0 | Vulnerability Database | Aqua Security](https://avd.aquasec.com/compliance/softwaresupplychain/cis-1.0/)
 * [ossf/allstar: GitHub App to set and enforce security policies](https://github.com/ossf/allstar)
+* [oss-reproducible](https://github.com/microsoft/OSSGadget/tree/main/src/oss-reproducible) - Measures the reproducibility of a package based on its purported source. Part of [OSS Gadget](https://github.com/microsoft/OSSGadget).
 
 Also see:
 


### PR DESCRIPTION
This PR adds one of our tools to the build section. OSS Reproducible attempts to rebuild a package from its purported source -- essentially measuring how closely we can re-generate the package automatically.