### PR TITLE
Add SCA tools comparison resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Also read:
 > This section includes: package/library scanners and detectors, SBOM formats, standards, authoring and validation, and a few applications. Will likely include SCA.
 
 The most complete reference is [awesomeSBOM/awesome-sbom](https://github.com/awesomeSBOM/awesome-sbom). Another helpful repo focusing on generators is [cybeats/sbomgen: List of SBOM Generation Tools](https://github.com/cybeats/sbomgen).
+* [AppSec Santa — SCA Tools](https://appsecsanta.com/sca-tools) - Curated comparison of SCA tools with features, pricing, and alternatives.
 
 * [GitBOM](https://gitbom.dev/)
   * Also: [git-bom/bomsh: bomsh is collection of tools to explore the GitBOM idea](https://github.com/git-bom/bomsh#Reproducible-Build-and-Bomsh)


### PR DESCRIPTION
## What is this?

Adding [AppSec Santa — SCA Tools](https://appsecsanta.com/sca-tools) to the **SCA and SBOM** section.

The page provides a side-by-side comparison of software composition analysis tools — covering features, open-source vs. commercial licensing, and alternatives. It complements the existing tool links and SBOM resources in this section by offering a structured overview for practitioners evaluating SCA tooling.

Independently maintained, no vendor affiliation.