### PR TITLE
Add brood-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Also see:
     * Or [Checkmarx/chainjacking: Find which of your go lang direct GitHub dependencies is susceptible to ChainJacking attack](https://github.com/Checkmarx/chainjacking)
     * Or [Cargo Vet](https://mozilla.github.io/cargo-vet/) and [crev-dev/cargo-crev: A cryptographically verifiable code review system for the cargo (Rust) package manager.](https://github.com/crev-dev/cargo-crev)
     * Not automated validation, but comprehensive guidance for Java with a few critical points relating to supply chain security: [Google Best Practices for Java Libraries](https://jlbp.dev/)
+* [stacklok/brood-box: CLI tool for running coding agents inside hardware-isolated microVMs with workspace snapshot isolation, egress control, and MCP authorization](https://github.com/stacklok/brood-box)
 * Static analysis is often used at this stage in order to detect dependency acquisition, e.g.:
   * [Semgrep](https://semgrep.dev/)
     * [Getting started with Semgrep Supply Chain](https://semgrep.dev/docs/semgrep-sc/scanning-open-source-dependencies/)


### PR DESCRIPTION
Brood-box is a CLI tool that runs coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs, preventing supply chain attacks by sandboxing agent execution with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles.

By isolating agent runtimes in microVMs with copy-on-write workspace snapshots and interactive file review, brood-box ensures that compromised dependencies or malicious agent behavior cannot exfiltrate secrets, tamper with source code, or reach unauthorized network endpoints — directly addressing point-of-use supply chain risks in AI-assisted development workflows.

Note: same maintainer as [awesome-agent-runtime-security](https://github.com/jamesbrink/awesome-agent-runtime-security) where we already have PR [#2](https://github.com/jamesbrink/awesome-agent-runtime-security/pull/2).

🤖 Generated with [Claude Code](https://claude.ai/code) and [Brood Box](https://github.com/stacklok/brood-box)