### PR TITLE
Add resource on securing APIs using OIDC and GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ And a few things to watch beyond libraries and software dependencies:
 * [transmute-industries/verifiable-actions: Workflow tools for Decentralized Identifiers &amp; Verifiable Credentials](https://github.com/transmute-industries/verifiable-actions/tree/main)
 * [IOTA Notarization](https://www.iota.org/products/notarization) is an open-source toolkit for anchoring, updating and verifying data integrity on a decentralized ledger, supporting locked (immutable) and dynamic notarization modes. See [iotaledger](https://github.com/iotaledger) on GitHub
 * Watch: [Privacy-preserving Approaches to Transparency Logs](https://www.youtube.com/watch?v=UrLdEYVASak)
+* [eparon/oidc-secure-api-github-actions: Lab demonstrating secretless API protection using GitHub Actions OIDC tokens validated by Envoy Proxy's jwt_authn and Lua-based authorization, with a mock OAuth2 server and act for local simulation](https://github.com/eparon/oidc-secure-api-github-actions). Read: [How to Secure APIs Using OIDC and GitHub Actions (No Secrets)](https://eparon.me/posts/2026-03-24-oidc-gh-actions-p2/), also see [Part 1: OIDC fundamentals and GitHub Actions token mechanics](https://eparon.me/posts/2026-02-28-oidc-gh-actions-p1/)
 
 ## Frameworks and best practice references
 


### PR DESCRIPTION
## What

Adds `eparon/oidc-secure-api-github-actions` to the Identity, signing and provenance section, with links to the two-part blog series covering the implementation.

The lab demonstrates a secretless API access pattern: GitHub Actions emits an OIDC token, which Envoy verifies using built-in capabilities (`jwt_authn`) before granting access to the upstream service. Includes Lua-based claims authorization, a local simulation setup using `act` and `navikt/mock-oauth2-server`, and Kubernetes deployment manifests.

## Why this section

The series covers both sides of the attestation lifecycle as framed in the list's About:
- Part 1 covers token emission — how GitHub Actions issues OIDC JWTs, what claims they carry, and how to reason about the issuer trust chain
- Part 2 covers token verification (authentication and authorization) — enforcing that attestation at the API boundary using Envoy's built-in capabilities

## Links

- Companion repo: https://github.com/eparon/oidc-secure-api-github-actions
- Part 1: https://eparon.me/posts/2026-02-28-oidc-gh-actions-p1/
- Part 2: https://eparon.me/posts/2026-03-24-oidc-gh-actions-p2/

---
Happy to adjust placement, description, or incorporate any feedback if needed.