### PR TITLE
Add Capa: capability-typed language emitting per-function SBOM/VEX/SLSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ A few open source projects are documenting, in public, how they acquire dependen
 * [What curl expects from dependencies](https://daniel.haxx.se/blog/2022/03/28/what-curl-expects-from-dependencies/)
 * [Security: The Value of SBOMs](https://fluxcd.io/blog/2022/02/security-the-value-of-sboms/) from Flux
 - [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with integrated supply chain security (SBOM, SLSA, Sigstore/Cosign, Kyverno policy), CNCF Sandbox project.
-* [nelsonduarte/capa: A capability-typed programming language whose compiler emits CycloneDX 1.5, SPDX 2.3, CycloneDX VEX, and SLSA L1 provenance directly from function signatures, with per-function granularity for declared capabilities (Fs/Net/Env/...) and user-defined capabilities. Includes a worked example of sandboxing LLM agent tool-use via the type system](https://github.com/nelsonduarte/capa)
+* [nelsonduarte/capa-language: A capability-typed programming language whose compiler emits CycloneDX 1.5, SPDX 2.3, CycloneDX VEX, and SLSA L1 provenance directly from function signatures, with per-function granularity for declared capabilities (Fs/Net/Env/...) and user-defined capabilities. Includes a worked example of sandboxing LLM agent tool-use via the type system](https://github.com/nelsonduarte/capa-language)
 
 ### Vulnerability information exchange
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ A few open source projects are documenting, in public, how they acquire dependen
 * [What curl expects from dependencies](https://daniel.haxx.se/blog/2022/03/28/what-curl-expects-from-dependencies/)
 * [Security: The Value of SBOMs](https://fluxcd.io/blog/2022/02/security-the-value-of-sboms/) from Flux
 - [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with integrated supply chain security (SBOM, SLSA, Sigstore/Cosign, Kyverno policy), CNCF Sandbox project.
+* [nelsonduarte/capa: A capability-typed programming language whose compiler emits CycloneDX 1.5, SPDX 2.3, CycloneDX VEX, and SLSA L1 provenance directly from function signatures, with per-function granularity for declared capabilities (Fs/Net/Env/...) and user-defined capabilities. Includes a worked example of sandboxing LLM agent tool-use via the type system](https://github.com/nelsonduarte/capa)
 
 ### Vulnerability information exchange
 


### PR DESCRIPTION
Adds Capa, a capability-typed programming language whose compiler natively emits the supply-chain governance artefact set (CycloneDX 1.5, SPDX 2.3, CycloneDX VEX, SLSA L1 provenance) from function signatures, at per-function granularity rather than per-package.

What distinguishes it from existing entries in this section:
- Capa is the *source language*, not a scanner of existing code. The manifest is a property of the type system, not an approximation by static analysis.
- Per-function attribution: each function declares the capabilities (`Fs`, `Net`, `Env`, `Clock`, `Random`, `Unsafe`, plus user-defined capabilities) it can exercise. The SBOM travels at that granularity.
- Includes a worked example (`examples/llm_anthropic_agent.capa`) of sandboxing a real Anthropic-model agent's tool-use authority where the agent loop provably excludes capabilities it does not declare, even with a real model in the loop deciding tool calls.

Website: https://capa-language.com/
Writeup of the LLM tool-use case: https://github.com/nelsonduarte/capa/blob/main/docs/llm-tool-sandbox.md

Adding to the SCA and SBOM section as the entry fits the "SBOM authoring" theme.