### PR TITLE
Add Lab700xOrg/aisbom — ML model file scanner generating CycloneDX/SPDX SBOMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ The most complete reference is [awesomeSBOM/awesome-sbom](https://github.com/awe
 * [cyfinoid/aibommaker: AI BOM Generator](https://github.com/cyfinoid/aibommaker), a client-side web tool for analyzing GitHub repositories for AI/LLM usage and generating AI Bills of Materials in CycloneDX 1.7 and SPDX 3.0.1 formats with hardware, infrastructure, and governance detection
 * [trustification/AIBOM-generator: Generate AI Bills of Materials for Hugging Face models](https://github.com/trustification/AIBOM-generator), documenting AI model dependencies and provenance
 * [Trusera/ai-bom: AI Bill of Materials generator for agent workflows](https://github.com/Trusera/ai-bom), scanning n8n, LangGraph, and CrewAI workflows for AI components and generating SBOM output in CycloneDX and SPDX formats
-
+* [Lab700xOrg/aisbom: Static malware and license scanner for ML model files](https://github.com/Lab700xOrg/aisbom), disassembling Pickle bytecode and parsing SafeTensors/GGUF binary headers to detect RCE-capable payloads and license risks before model load; generates CycloneDX/SPDX SBOMs and supports remote HTTP-range scanning of Hugging Face models with no weights downloaded.
+ 
 More interesting resources:
 
 * [Brakeing Down Security Podcast: 2020-031-Allan Friedman, SBOM, software transparency, and knowing how the sausage is made](https://brakeingsecurity.com/2020-031-allan-friedman-sbom-software-transparency-and-knowing-how-the-sausage-is-made?tdest_id=282477)


### PR DESCRIPTION
This PR adds [Lab700xOrg/aisbom](https://github.com/Lab700xOrg/aisbom) to the SCA and SBOM section.

**Why this fits the list:** ML model files (`.pt`, `.safetensors`, `.gguf`) are increasingly the highest-value, most-trafficked artifacts in modern software supply chains, but generic SCA / SBOM tools treat them as opaque blobs. AIsbom is the missing piece - it disassembles Python Pickle bytecode and parses SafeTensors / GGUF binary headers to detect malware (RCE payloads via `os.system`, `subprocess`, `eval`) and license risks (e.g., non-commercial weights baked into the header), then emits CycloneDX v1.6 or SPDX 2.3 SBOMs that plug into the rest of the supply-chain toolchain mentioned in this list.

**Notable capabilities:**

- Remote scanning via HTTP Range requests (`aisbom scan hf://google-bert/bert-base-uncased`) - no weights pulled to disk.
- [GitHub Action on the Marketplace](https://github.com/marketplace/actions/aisbom-security-scanner) for PR-comment-driven enforcement.
- Public weekly [advisories](https://aisbom.io/advisories) on the top 50 Hugging Face text-generation models.
- Apache 2.0 licensed.

Thanks for curating this list.