### PR TITLE
Add CVE PoC Search to vulnerability information exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ A few open source projects are documenting, in public, how they acquire dependen
 * [Vuls · Agentless Vulnerability Scanner for Linux/FreeBSD](https://vuls.io/)
 * [Vulnerability Database](https://vuldb.com/?), an [API](https://vuldb.com/?kb.api) is also available; see [VulDB](https://github.com/vuldb)
 * [AppThreat/vulnerability-db: Vulnerability database and package search for sources such as OSV, NVD, GitHub and npm.](https://github.com/AppThreat/vulnerability-db)
+* [CVE PoC Search](https://labs.jamessawyer.co.uk/cves/) - Search public GitHub proof-of-concept repositories by CVE identifier to quickly pivot from disclosed dependency vulnerabilities to known exploit code.
 * [vulnerability-lookup/vulnerability-lookup: Vulnerability correlation platform with multi-source feeds](https://github.com/vulnerability-lookup/vulnerability-lookup) (NVD, GitHub, OSV, national databases), CVD management, sightings tracking, comments, bundles, and API for rapid lookup and cross-source correlation
 * [aquasecurity/trivy: Scanner for vulnerabilities in container images, file systems, and Git repositories, as well as for configuration issues](https://github.com/aquasecurity/trivy)
 * [SAST for Code Security | Snyk Code](https://snyk.io/product/snyk-code/)


### PR DESCRIPTION
Adds CVE PoC Search under the vulnerability information exchange section as a public resource for finding GitHub proof-of-concept repositories by CVE identifier. This helps teams quickly pivot from a disclosed dependency vulnerability to known public exploit code.