### PR TITLE
Add StackHealth — open code health benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ A few open source projects are documenting, in public, how they acquire dependen
   * Read: [How OpenSSF Scorecards can help to evaluate open-source software risks](https://www-csoonline-com.cdn.ampproject.org/c/s/www.csoonline.com/article/3668192/how-openssf-scorecards-can-help-to-evaluate-open-source-software-risks.amp.html)
   * Great real life example: [State of the Eclipse Foundation GitHub repositories](https://mikael.barbero.tech/blog/post/eclipsefdn-scorecard-aug2022/)
   * Also see: [naveensrinivasan/scorecard-1000-critical-projects](https://github.com/naveensrinivasan/scorecard-1000-critical-projects), using the Scorecard API to analyze the top 1000 critical open source projects from the [Criticality Score](https://github.com/ossf/criticality_score) dataset
+* [santosh3743/stackhealth: Open code health benchmark for any public GitHub repo. Aggregates OpenSSF Scorecard, Semgrep, Trivy, and language-native linters into a 0–100 composite score across security, quality, hygiene, and community. Fully open, versioned formula](https://github.com/santosh3743/stackhealth), [live at stackhealth.dev](https://stackhealth.dev)
 * [Lynis - Security auditing and hardening tool for Linux/Unix](https://cisofy.com/lynis/)
 * [victims/victims-cve-db: CVE database store](https://github.com/victims/victims-cve-db)
 * [anchore/grype: A vulnerability scanner for container images and filesystems](https://github.com/anchore/grype)


### PR DESCRIPTION
Hi! Adding StackHealth — an open code health benchmark for any public GitHub repo.

It aggregates OpenSSF Scorecard, Semgrep, Trivy, and language-native linters into a 0–100 composite score across four dimensions (security, quality, hygiene, community). The formula is versioned (v1.0) and fully documented; every scan stores the formula version, tool versions, exact commit SHA, and raw analyzer outputs, so any score is end-to-end reproducible.

Placed it next to OpenSSF Scorecard since the two are conceptually closest — both open-formula health metrics for open-source code. Happy to move if you'd rather have it under a different subsection.

- Repo: https://github.com/santosh3743/stackhealth
- Methodology: https://stackhealth.dev/methodology
- Live: https://stackhealth.dev
- License: MIT. Free for public repos.