### PR TITLE
Add Dependency Guardian

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Also see:
 ## Point-of-use validations
 
 > This section includes: admission and ingestion policies, pull-time verification and end-user verifications.
+* [WestBayBerry/DG_CLI: blocks malicious npm and PyPI packages at install time with behavioral scanning, before the package install scripts run, plus a native install hook for AI coding agents](https://github.com/WestBayBerry/DG_CLI)
 
 * [grafeas/kritis: Solution for securing your software supply chain for Kubernetes apps, enforcing deploy-time security policies](https://github.com/grafeas/kritis)
 * [spaceraccoon/vulnerability-spoiler-alert: AI-powered monitoring hub that watches open-source repositories and detects security vulnerability patches before CVEs are assigned, with RSS feed and web interface](https://github.com/spaceraccoon/vulnerability-spoiler-alert)


### PR DESCRIPTION
Adds **Dependency Guardian**, a supply chain scanner for npm and PyPI that blocks malicious packages at install time (behavioral scanning of the published artifact) and ships a native install hook for AI coding agents (Claude Code, Cursor, Codex).

- Site: https://westbayberry.com
- Source: https://github.com/WestBayBerry/DG_CLI
- npm: https://www.npmjs.com/package/@westbayberry/dg (≈2k weekly downloads)

Placed under **Point-of-use validations** alongside similar install-time tooling. Happy to adjust the section or wording.