### PR TITLE
Add wille/gh-actions-cli under Build techniques

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ Also see:
 * [stagex.tools: Decentralized, bootstrappable, reproducible Linux distribution with native OCI layer support and Containerfile-based build definitions](https://stagex.tools/)
 * [GoogleContainerTools/kaniko: Build Container Images In Kubernetes](https://github.com/GoogleContainerTools/kaniko)
 * [sethvargo/ratchet: A tool for securing CI/CD workflows with version pinning.](https://github.com/sethvargo/ratchet)
+* [wille/gh-actions-cli: Pin GitHub Actions to commit SHAs, enforce allowed-actions policies, and update pinned actions from the terminal](https://github.com/wille/gh-actions-cli)
 * [Pinning GitHub Actions](https://pin-gh-actions.kammel.dev/) guide with statistics on SHA pinning adoption and tools like Frizbee for migration and Renovate for automated updates
 * [buildsec/vendorme](https://github.com/buildsec/vendorme) improves the developer workflow by giving you one single place to manage any vendored dependencies, and ensures that those are validated properly to improve the security around your supply chain
 * [eellak/build-recorder](https://github.com/eellak/build-recorder)


### PR DESCRIPTION
Adds **gh-actions-cli** (`gha`) — an MIT-licensed Go CLI that hardens GitHub Actions usage: pins every `uses:` ref to a commit SHA (with a CI gate for unpinned actions), generates and applies GitHub's allowed-actions allowlist policy from what workflows actually use, enables the new `sha_pinning_required` repo setting, and safely updates pinned actions.

Placed under *Build techniques* next to `sethvargo/ratchet`, which covers the pinning half of the same problem; this also covers policy enforcement. Motivated by the tj-actions/changed-files compromise.