### PR TITLE
Add open-dependency-risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Using this lens we can identify a large group of "subjects" (dependencies), dist
 * [OpenSourceMalware.com: Community-driven threat intelligence platform for checking malicious packages, repositories, and containers across ecosystems, plus threat reporting and feed integration](https://opensourcemalware.com/) ([API docs](https://docs.opensourcemalware.com/api/overview))
 * [santhsecurity/keyhog: High-performance secrets scanner with 900+ detectors and GPU acceleration support, scanning source trees, git history, Docker images, S3 buckets, and runtime environments for leaked credentials and malicious indicators](https://github.com/santhsecurity/keyhog)
 * [irchaosclub/FANGS: eBPF-based npm package behavior monitoring system that runs releases in Docker sandbox, captures syscalls and network activity via kernel instrumentation, and flags behavioral deviations from baseline to detect supply chain anomalies](https://github.com/irchaosclub/FANGS)
+* [ConorsCode/open-dependency-risk: Free, daily-updated dataset of 1,500 widely-used npm and PyPI packages ranked by weekly downloads, enriched with registry metadata and OSV.dev vulnerability data](https://github.com/ConorsCode/open-dependency-risk)
 
 Also read:
 


### PR DESCRIPTION
Adds ConorsCode/open-dependency-risk, a free, daily-updated dataset of 1,500 widely-used npm and PyPI packages ranked by weekly downloads, enriched with registry metadata and OSV.dev vulnerability data. MIT licensed, JSON + CSV, refreshed daily by GitHub Actions. Added to the Dependency intelligence section alongside the other dependency-data sources.