### PR TITLE
Add VulnFuse vulnerability correlator

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ A few open source projects are documenting, in public, how they acquire dependen
 * See the [Vulnerability Management](https://open-docs.neuvector.com/scanning/scanning/vulnerabilities) in the NeuVector Docs for integration examples in container scenarios
 * [noqcks/xeol: An end-of-life (EOL) package scanner for container images, systems, and SBOMs](https://github.com/noqcks/xeol)
 * [mchmarny/vimp: Compare data from multiple vulnerability scanners to get a more complete picture of potential exposures.](https://github.com/mchmarny/vimp)
+* [CAOShurong/vulnfuse: Local-first CLI, browser workbench, and GitHub Action for explainable correlation and deduplication across SARIF, Trivy, Grype, Snyk, CycloneDX VDR/VEX, OSV-Scanner, and CSV vulnerability reports](https://github.com/CAOShurong/vulnfuse)
 
 A dedicated section on VEX reads:
 


### PR DESCRIPTION
Disclosure: I maintain VulnFuse. This adds one entry to the Vulnerability information exchange section, next to other multi-scanner comparison and correlation tools.

VulnFuse normalizes and explains correlations across SARIF, Trivy, Grype, Snyk, CycloneDX VDR/VEX, OSV-Scanner, CSV, and its canonical JSON format. It measures per-scanner exclusive/shared clusters and pairwise overlap, compares runs as new, updated, unchanged, or absent, and exports one self-contained interactive HTML review, while running locally as a CLI, browser workbench, or GitHub Action.

Project: https://github.com/CAOShurong/vulnfuse
Release used for verification: https://github.com/CAOShurong/vulnfuse/releases/tag/v0.4.2