### PR TITLE
Add rung to Point-of-use validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ And a few things to watch beyond libraries and software dependencies:
 * [keylime/keylime: A CNCF Project to Bootstrap &amp; Maintain Trust on the Edge / Cloud and IoT](https://github.com/keylime/keylime)
 * [parallaxsecond/parsec: Platform AbstRaction for SECurity service](https://github.com/parallaxsecond/parsec)
 * [TPM Carte Blanche-resistant Boot Attestation](https://www.dlp.rip/tcb-attestation)
+* [rung-dev/rung: deterministic, AI-free CI gate that verifies an AI coding agent actually ran the checks it claims, reading a machine-checkable evidence bundle at pull-time to pass or block the build; ships as a GitHub Action and CLI](https://github.com/rung-dev/rung)
 
 ## Identity, signing and provenance
 


### PR DESCRIPTION
Adds [rung](https://github.com/rung-dev/rung) to **Point-of-use validations**.

rung is a deterministic, AI-free CI gate for verifying AI coding agents. An agent produces a machine-checkable evidence bundle from a real run; rung's gate reads it at pull-time and passes (exit 0) or blocks (exit 30) the build. It fits this section as an end-user / pull-time verification of agent-run attestations, rather than artifact provenance.

- One entry, appended to the section.
- Searched for duplicates first; not already listed.
- Repository: https://github.com/rung-dev/rung (Apache-2.0). Ships as a GitHub Action and CLI.