### PR TITLE
Add cosign-verify-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ And a few things to watch beyond libraries and software dependencies:
 * [keylime/keylime: A CNCF Project to Bootstrap &amp; Maintain Trust on the Edge / Cloud and IoT](https://github.com/keylime/keylime)
 * [parallaxsecond/parsec: Platform AbstRaction for SECurity service](https://github.com/parallaxsecond/parsec)
 * [TPM Carte Blanche-resistant Boot Attestation](https://www.dlp.rip/tcb-attestation)
+* [cosign-verify-init](https://github.com/fabiocicerchia/cosign-verify-init) - Kubernetes init container that verifies cosign image signatures before the workload starts.
 
 ## Identity, signing and provenance
 


### PR DESCRIPTION
Adds [cosign-verify-init](https://github.com/fabiocicerchia/cosign-verify-init) under **Supply chain beyond libraries**.

> Kubernetes init container that verifies cosign image signatures before the workload starts.

Disclosure: I am the author of this project.

One addition in a single commit, formatted and ordered to match the surrounding entries in that section.